### PR TITLE
DiscordSRV fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ml.treecaptcha</groupId>
     <artifactId>uwuify</artifactId>
-    <version>1.4</version>
+    <version>1.5</version>
     <packaging>jar</packaging>
 
     <name>Uwuify</name>

--- a/src/main/java/ml/treecaptcha/uwuify/paper/PaperChatHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/paper/PaperChatHandler.java
@@ -16,7 +16,4 @@ public class PaperChatHandler implements Listener {
         PlainTextComponentSerializer serializer = PlainTextComponentSerializer.plainText();
         event.result(Component.text(Uwuifier.uwuifyMessage(serializer.serialize(event.result()))));
     }
-    public PaperChatHandler(Uwuify uwuify) {
-        uwuify.getServer().getPluginManager().registerEvents(this, uwuify);
-    }
 }

--- a/src/main/java/ml/treecaptcha/uwuify/paper/PaperChatHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/paper/PaperChatHandler.java
@@ -3,7 +3,6 @@ package ml.treecaptcha.uwuify.paper;
 import io.github.ran.uwu.client.Uwuifier;
 import io.papermc.paper.event.player.AsyncChatDecorateEvent;
 import ml.treecaptcha.uwuify.core.Configuration;
-import ml.treecaptcha.uwuify.spigot.Uwuify;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/ml/treecaptcha/uwuify/paper/PaperChatHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/paper/PaperChatHandler.java
@@ -1,0 +1,22 @@
+package ml.treecaptcha.uwuify.paper;
+
+import io.github.ran.uwu.client.Uwuifier;
+import io.papermc.paper.event.player.AsyncChatDecorateEvent;
+import ml.treecaptcha.uwuify.core.Configuration;
+import ml.treecaptcha.uwuify.spigot.Uwuify;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PaperChatHandler implements Listener {
+    @EventHandler
+    public void onPlayerPreview(AsyncChatDecorateEvent event) {
+        if(event.isPreview() && !Configuration.USE_PREVIEW) return;
+        PlainTextComponentSerializer serializer = PlainTextComponentSerializer.plainText();
+        event.result(Component.text(Uwuifier.uwuifyMessage(serializer.serialize(event.result()))));
+    }
+    public PaperChatHandler(Uwuify uwuify) {
+        uwuify.getServer().getPluginManager().registerEvents(this, uwuify);
+    }
+}

--- a/src/main/java/ml/treecaptcha/uwuify/paper/PaperUwuHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/paper/PaperUwuHandler.java
@@ -23,21 +23,7 @@ public class PaperUwuHandler implements Listener {
         uwuify.getServer().getPluginManager().registerEvents(this, uwuify);
     }
 
-    //Workaround for if the player uses DiscordSRV but doesn't have the DiscordSRV config set to use Paper's chat event.
-    @EventHandler(priority = EventPriority.NORMAL)
-    public void onPlayerChat(AsyncPlayerChatEvent event) {
-        if(Uwuify.DISCORDSRV_PAPER) return;
-        event.setMessage(Uwuifier.uwuifyMessage(event.getMessage()));
-        Uwuify.uwu.getLogger().log(Level.WARNING, Uwuifier.uwuify("DiscordSRV is not set to use Paper's chat event."));
-        Uwuify.uwu.getLogger().log(Level.WARNING, Uwuifier.uwuify("Please set DiscordSRV's config to use Paper's chat event."));
-    }
 
-    @EventHandler
-    public void onPlayerPreview(AsyncChatDecorateEvent event) {
-        if(!Configuration.USE_PREVIEW) return;
-        PlainTextComponentSerializer serializer = PlainTextComponentSerializer.plainText();
-        event.result(Component.text(Uwuifier.uwuifyMessage(serializer.serialize(event.result()))));
-    }
 
     @EventHandler
     public void onSignChange(org.bukkit.event.block.SignChangeEvent e) {

--- a/src/main/java/ml/treecaptcha/uwuify/paper/PaperUwuHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/paper/PaperUwuHandler.java
@@ -24,7 +24,7 @@ public class PaperUwuHandler implements Listener {
     }
 
     //Workaround for if the player uses DiscordSRV but doesn't have the DiscordSRV config set to use Paper's chat event.
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerChat(AsyncPlayerChatEvent event) {
         if(Uwuify.DISCORDSRV_PAPER) return;
         event.setMessage(Uwuifier.uwuifyMessage(event.getMessage()));

--- a/src/main/java/ml/treecaptcha/uwuify/paper/PaperUwuHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/paper/PaperUwuHandler.java
@@ -1,20 +1,35 @@
 package ml.treecaptcha.uwuify.paper;
 
+import com.google.gson.Gson;
 import io.github.ran.uwu.client.Uwuifier;
 import io.papermc.paper.event.player.AsyncChatDecorateEvent;
+import io.papermc.paper.event.player.AsyncChatEvent;
 import ml.treecaptcha.uwuify.core.Configuration;
 import ml.treecaptcha.uwuify.spigot.Uwuify;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerEditBookEvent;
 import org.bukkit.inventory.meta.BookMeta;
+
+import java.util.logging.Level;
 
 public class PaperUwuHandler implements Listener {
 
     public PaperUwuHandler(Uwuify uwuify) {
         uwuify.getServer().getPluginManager().registerEvents(this, uwuify);
+    }
+
+    //Workaround for if the player uses DiscordSRV but doesn't have the DiscordSRV config set to use Paper's chat event.
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerChat(AsyncPlayerChatEvent event) {
+        if(Uwuify.DISCORDSRV_PAPER) return;
+        event.setMessage(Uwuifier.uwuifyMessage(event.getMessage()));
+        Uwuify.uwu.getLogger().log(Level.WARNING, Uwuifier.uwuify("DiscordSRV is not set to use Paper's chat event."));
+        Uwuify.uwu.getLogger().log(Level.WARNING, Uwuifier.uwuify("Please set DiscordSRV's config to use Paper's chat event."));
     }
 
     @EventHandler

--- a/src/main/java/ml/treecaptcha/uwuify/paper/PaperUwuHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/paper/PaperUwuHandler.java
@@ -19,9 +19,7 @@ import java.util.logging.Level;
 
 public class PaperUwuHandler implements Listener {
 
-    public PaperUwuHandler(Uwuify uwuify) {
-        uwuify.getServer().getPluginManager().registerEvents(this, uwuify);
-    }
+
 
 
 

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotChatHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotChatHandler.java
@@ -19,8 +19,5 @@ public class SpigotChatHandler implements Listener {
         if(!Configuration.USE_PREVIEW) return;
         event.setMessage(Uwuifier.uwuifyMessage(event.getMessage()));
     }
-    public SpigotChatHandler(Uwuify plugin){
-        plugin.getServer().getPluginManager().registerEvents(this, plugin);
-    }
 
 }

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotChatHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotChatHandler.java
@@ -9,7 +9,7 @@ import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.AsyncPlayerChatPreviewEvent;
 
 public class SpigotChatHandler implements Listener {
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler
     public void onPlayerChat(AsyncPlayerChatEvent event) {
         event.setMessage(Uwuifier.uwuifyMessage(event.getMessage()));
     }

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotChatHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotChatHandler.java
@@ -1,0 +1,26 @@
+package ml.treecaptcha.uwuify.spigot;
+
+import io.github.ran.uwu.client.Uwuifier;
+import ml.treecaptcha.uwuify.core.Configuration;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.AsyncPlayerChatPreviewEvent;
+
+public class SpigotChatHandler implements Listener {
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onPlayerChat(AsyncPlayerChatEvent event) {
+        event.setMessage(Uwuifier.uwuifyMessage(event.getMessage()));
+    }
+
+    @EventHandler
+    public void onPlayerPreview(AsyncPlayerChatPreviewEvent event) {
+        if(!Configuration.USE_PREVIEW) return;
+        event.setMessage(Uwuifier.uwuifyMessage(event.getMessage()));
+    }
+    public SpigotChatHandler(Uwuify plugin){
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+}

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotUwuHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotUwuHandler.java
@@ -11,7 +11,7 @@ import org.bukkit.event.player.PlayerEditBookEvent;
 import org.bukkit.inventory.meta.BookMeta;
 
 public class SpigotUwuHandler implements Listener {
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerChat(AsyncPlayerChatEvent event) {
         event.setMessage(Uwuifier.uwuifyMessage(event.getMessage()));
     }

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotUwuHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotUwuHandler.java
@@ -1,26 +1,15 @@
 package ml.treecaptcha.uwuify.spigot;
+
 import io.github.ran.uwu.client.Uwuifier;
-import ml.treecaptcha.uwuify.core.Configuration;
-import org.bukkit.event.EventPriority;
+
 import org.bukkit.event.Listener;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.SignChangeEvent;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.event.player.AsyncPlayerChatPreviewEvent;
 import org.bukkit.event.player.PlayerEditBookEvent;
 import org.bukkit.inventory.meta.BookMeta;
 
 public class SpigotUwuHandler implements Listener {
-    @EventHandler(priority = EventPriority.NORMAL)
-    public void onPlayerChat(AsyncPlayerChatEvent event) {
-        event.setMessage(Uwuifier.uwuifyMessage(event.getMessage()));
-    }
 
-    @EventHandler
-    public void onPlayerPreview(AsyncPlayerChatPreviewEvent event) {
-        if(!Configuration.USE_PREVIEW) return;
-        event.setMessage(Uwuifier.uwuifyMessage(event.getMessage()));
-    }
 
     @EventHandler
     public void onPlayerSign(SignChangeEvent event) {

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotUwuHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotUwuHandler.java
@@ -34,7 +34,5 @@ public class SpigotUwuHandler implements Listener {
         event.setNewBookMeta(meta);
     }
 
-    public SpigotUwuHandler(Uwuify plugin){
-        plugin.getServer().getPluginManager().registerEvents(this, plugin);
-    }
+
 }

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotUwuHandler.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/SpigotUwuHandler.java
@@ -1,6 +1,7 @@
 package ml.treecaptcha.uwuify.spigot;
 import io.github.ran.uwu.client.Uwuifier;
 import ml.treecaptcha.uwuify.core.Configuration;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.SignChangeEvent;
@@ -10,7 +11,7 @@ import org.bukkit.event.player.PlayerEditBookEvent;
 import org.bukkit.inventory.meta.BookMeta;
 
 public class SpigotUwuHandler implements Listener {
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerChat(AsyncPlayerChatEvent event) {
         event.setMessage(Uwuifier.uwuifyMessage(event.getMessage()));
     }

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/Uwuify.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/Uwuify.java
@@ -3,8 +3,11 @@ package ml.treecaptcha.uwuify.spigot;
 import ml.treecaptcha.uwuify.core.Configuration;
 import ml.treecaptcha.uwuify.paper.PaperUwuHandler;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.File;
 import java.util.logging.Level;
 
 import io.github.ran.uwu.client.Uwuifier;
@@ -70,7 +73,9 @@ public final class Uwuify extends JavaPlugin {
     public static void checkDiscordSRV() {
         if(uwu.getServer().getPluginManager().isPluginEnabled("DiscordSRV")) {
             //get DiscordSRV's Config
-            FileConfiguration discordSRVConfig = uwu.getServer().getPluginManager().getPlugin("DiscordSRV").getConfig();
+            Plugin discordSRV = uwu.getServer().getPluginManager().getPlugin("DiscordSRV");
+            //get the config file the annoying way.
+            YamlConfiguration discordSRVConfig = YamlConfiguration.loadConfiguration(new File(discordSRV.getDataFolder(), "config.yml"));
             DISCORDSRV_PAPER = discordSRVConfig.getBoolean("UseModernPaperChatEvent");
         }
     }

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/Uwuify.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/Uwuify.java
@@ -1,16 +1,19 @@
 package ml.treecaptcha.uwuify.spigot;
 
+import io.github.ran.uwu.client.Uwuifier;
 import ml.treecaptcha.uwuify.core.Configuration;
+import ml.treecaptcha.uwuify.paper.PaperChatHandler;
 import ml.treecaptcha.uwuify.paper.PaperUwuHandler;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
+import java.util.InputMismatchException;
+import java.util.List;
 import java.util.logging.Level;
 
-import io.github.ran.uwu.client.Uwuifier;
 public final class Uwuify extends JavaPlugin {
     public static Uwuify uwu;
     /**
@@ -23,28 +26,13 @@ public final class Uwuify extends JavaPlugin {
 
     public static String PLATFORM;
 
-    @Override
-    public void onEnable() {
-        uwu = this;
-        getLogger().log(Level.INFO, Uwuifier.uwuify("give uwu sound effects cause idk where to get them"));
-        saveDefaultConfig();
-        initializeVariables();
-        checkPaper();
-        checkDiscordSRV();
-        loadChat();
-    }
-
-    @Override
-    public void onDisable() {
-        // Plugin shutdown logic
-    }
+    private List<Listener> listeners;
 
     private static void initializeVariables() {
-        if (uwu.getConfig().getBoolean("use-chat-preview")){
-            if (uwu.getServer().shouldSendChatPreviews()){
+        if (uwu.getConfig().getBoolean("use-chat-preview")) {
+            if (uwu.getServer().shouldSendChatPreviews()) {
                 Configuration.USE_PREVIEW = true;
-            }
-            else{
+            } else {
                 uwu.getLogger().log(Level.WARNING, Uwuifier.uwuify("use-chat-preview is set to true, but previews-chat is not enabled in server.properties!"));
                 uwu.getLogger().log(Level.WARNING, Uwuifier.uwuify("To stop this warn please either set use-chat-preview to false or set previews-chat to true."));
                 uwu.getLogger().log(Level.WARNING, Uwuifier.uwuify("Not enabling chat preview!"));
@@ -53,74 +41,87 @@ public final class Uwuify extends JavaPlugin {
         SIGNS_UWUIFY = uwu.getConfig().getBoolean("signs-uwuify");
         BOOKS_UWUIFY = uwu.getConfig().getBoolean("books-uwuify");
         CHAT_HANDLER = uwu.getConfig().getString("chat-handler");
+        PLATFORM = getPlatform();
+        String rec = getDiscordSRVRecommendation();
+        if (CHAT_HANDLER.equals("auto")) {
+            CHAT_HANDLER = rec;
+        }
     }
-    public static void checkPaper() {
+
+    public static String getPlatform() {
         try {
             Class.forName("io.papermc.paper.event.entity.WardenAngerChangeEvent");
-            PLATFORM = "paper";
-            loadPaper();
+            return "paper";
         } catch (ClassNotFoundException e) {
             uwu.getLogger().log(Level.INFO, Uwuifier.uwuify("You are not using Paper! We highly recommend you do so!"));
-            PLATFORM = "spigot";
-            loadSpigot();
+            return "spigot";
         }
     }
 
-    private static void loadSpigot() {
-        uwu.getLogger().log(Level.INFO, Uwuifier.uwuify("Loading Spigot version of uwuify!"));
-        new SpigotUwuHandler(uwu);
+    private static void registerListeners(JavaPlugin plugin, List<Listener> listenerList) {
+        for (Listener l : listenerList) {
+            plugin.getServer().getPluginManager().registerEvents(l, plugin);
+        }
     }
 
-    public static void loadPaper() {
-        uwu.getLogger().log(Level.INFO, Uwuifier.uwuify("Loading Paper version of uwuify!"));
-        new PaperUwuHandler(uwu);
+    private static Listener getUwuHandler() {
+        if (PLATFORM.equals("paper")) {
+            return new PaperUwuHandler();
+        }
+        if (PLATFORM.equals("spigot")) {
+            return new SpigotUwuHandler();
+        }
+        throw new InputMismatchException("THE PLATFORM WAS UNKNOWN!" +
+                "\nPLATFORM: " + PLATFORM);
     }
 
-    public static void loadChat(){
-        if (CHAT_HANDLER.equals("paper") && PLATFORM.equals("paper")){
-            loadPaperChat();
-        }
-        else if (CHAT_HANDLER.equals("spigot")){
-            loadSpigotChat();
-        }
-        else if (CHAT_HANDLER.equals("paper") && PLATFORM.equals("spigot") ){
+    private static Listener getChatHandler() {
+        if (CHAT_HANDLER.equals("paper") && PLATFORM.equals("paper")) {
+            return new PaperChatHandler();
+        } else if (CHAT_HANDLER.equals("spigot")) {
+            return new SpigotChatHandler();
+        } else if (CHAT_HANDLER.equals("paper") && PLATFORM.equals("spigot")) {
             uwu.getLogger().log(Level.SEVERE, "THE PLATFORM DOES NOT APPEAR TO BE PAPER YET \"paper\" WAS CHOSEN AS THE CHAT HANDLER!");
-            loadPaperChat();
-        }
-        else {
-            uwu.getLogger().log(Level.SEVERE, "THE CHAT HANDLER WAS UNKNOWN NOT ENABLING THE CHAT HANDLER!");
-            uwu.getLogger().log(Level.SEVERE, "HANDLER: " + CHAT_HANDLER + " SERVER: " + PLATFORM);
-
+            return new PaperChatHandler();
+        } else {
+            throw new InputMismatchException("THE CHAT HANDLER WAS UNKNOWN NOT ENABLING THE CHAT HANDLER!" +
+                    "\nHANDLER: " + CHAT_HANDLER + " SERVER: " + PLATFORM);
         }
     }
-    public static void loadPaperChat(){
-        uwu.getLogger().log(Level.INFO, Uwuifier.uwuify("Using paper as the chat provider!"));
-        new PaperUwuHandler(uwu);
-    }
 
-    public static void loadSpigotChat(){
-        uwu.getLogger().log(Level.INFO, Uwuifier.uwuify("Using spigot as the chat provider!"));
-        new SpigotChatHandler(uwu);
-    }
-
-    public static void checkDiscordSRV() {
-        if(uwu.getServer().getPluginManager().isPluginEnabled("DiscordSRV")) {
+    private static String getDiscordSRVRecommendation() {
+        if (uwu.getServer().getPluginManager().isPluginEnabled("DiscordSRV")) {
             //get DiscordSRV's Config
             Plugin discordSRV = uwu.getServer().getPluginManager().getPlugin("DiscordSRV");
             //get the config file the annoying way.
             YamlConfiguration discordSRVConfig = YamlConfiguration.loadConfiguration(new File(discordSRV.getDataFolder(), "config.yml"));
-            if(!discordSRVConfig.getBoolean("UseModernPaperChatEvent")){
+            if (!discordSRVConfig.getBoolean("UseModernPaperChatEvent")) {
                 uwu.getLogger().log(Level.WARNING, Uwuifier.uwuify("UseModernPaperChatEvent is not set to true in DiscordSRV config!"));
-                if (CHAT_HANDLER.equals("auto")){
-                    CHAT_HANDLER = "spigot";
-                    uwu.getLogger().log(Level.WARNING, Uwuifier.uwuify("Will initialise chat handler as a spigot server!"));
-                }
+                uwu.getLogger().log(Level.WARNING, Uwuifier.uwuify("Will initialise chat handler as a spigot server!"));
+                return "spigot";
             }
-
-            }
-        if (PLATFORM.equals("paper") && CHAT_HANDLER.equals("auto")){
-            CHAT_HANDLER = "paper";
-
         }
+        if (PLATFORM.equals("paper")) {
+            return "paper";
+        }
+        return "spigot";
+    }
+
+    @Override
+    public void onEnable() {
+        uwu = this;
+        getLogger().log(Level.INFO, Uwuifier.uwuify("give uwu sound effects cause idk where to get them"));
+        saveDefaultConfig();
+        initializeVariables();
+        listeners.add(getChatHandler());
+        listeners.add(getUwuHandler());
+        registerListeners(this, listeners);
+
+
+    }
+
+    @Override
+    public void onDisable() {
+        // Plugin shutdown logic
     }
 }

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/Uwuify.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/Uwuify.java
@@ -10,6 +10,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.InputMismatchException;
 import java.util.List;
 import java.util.logging.Level;
@@ -113,11 +114,10 @@ public final class Uwuify extends JavaPlugin {
         getLogger().log(Level.INFO, Uwuifier.uwuify("give uwu sound effects cause idk where to get them"));
         saveDefaultConfig();
         initializeVariables();
+        listeners = new ArrayList<>();
         listeners.add(getChatHandler());
         listeners.add(getUwuHandler());
         registerListeners(this, listeners);
-
-
     }
 
     @Override

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/Uwuify.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/Uwuify.java
@@ -2,6 +2,7 @@ package ml.treecaptcha.uwuify.spigot;
 
 import ml.treecaptcha.uwuify.core.Configuration;
 import ml.treecaptcha.uwuify.paper.PaperUwuHandler;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.logging.Level;
@@ -14,6 +15,7 @@ public final class Uwuify extends JavaPlugin {
      */
     public static boolean SIGNS_UWUIFY;
     public static boolean BOOKS_UWUIFY;
+    public static boolean DISCORDSRV_PAPER;
 
     @Override
     public void onEnable() {
@@ -22,6 +24,7 @@ public final class Uwuify extends JavaPlugin {
         saveDefaultConfig();
         initializeVariables();
         checkPaper();
+        checkDiscordSRV();
     }
 
     @Override
@@ -62,5 +65,13 @@ public final class Uwuify extends JavaPlugin {
     public static void loadPaper() {
         uwu.getLogger().log(Level.INFO, Uwuifier.uwuify("Loading Paper version of uwuify!"));
         new PaperUwuHandler(uwu);
+    }
+
+    public static void checkDiscordSRV() {
+        if(uwu.getServer().getPluginManager().isPluginEnabled("DiscordSRV")) {
+            //get DiscordSRV's Config
+            FileConfiguration discordSRVConfig = uwu.getServer().getPluginManager().getPlugin("DiscordSRV").getConfig();
+            DISCORDSRV_PAPER = discordSRVConfig.getBoolean("UseModernPaperChatEvent");
+        }
     }
 }

--- a/src/main/java/ml/treecaptcha/uwuify/spigot/Uwuify.java
+++ b/src/main/java/ml/treecaptcha/uwuify/spigot/Uwuify.java
@@ -88,14 +88,18 @@ public final class Uwuify extends JavaPlugin {
             loadPaperChat();
         }
         else {
-            uwu.getLogger().log(Level.SEVERE, "THE PLATFORM WAS UNKNOWN NOT ENABLING THE CHAT HANDLER!");
+            uwu.getLogger().log(Level.SEVERE, "THE CHAT HANDLER WAS UNKNOWN NOT ENABLING THE CHAT HANDLER!");
+            uwu.getLogger().log(Level.SEVERE, "HANDLER: " + CHAT_HANDLER + " SERVER: " + PLATFORM);
+
         }
     }
     public static void loadPaperChat(){
+        uwu.getLogger().log(Level.INFO, Uwuifier.uwuify("Using paper as the chat provider!"));
         new PaperUwuHandler(uwu);
     }
 
     public static void loadSpigotChat(){
+        uwu.getLogger().log(Level.INFO, Uwuifier.uwuify("Using spigot as the chat provider!"));
         new SpigotChatHandler(uwu);
     }
 
@@ -112,9 +116,11 @@ public final class Uwuify extends JavaPlugin {
                     uwu.getLogger().log(Level.WARNING, Uwuifier.uwuify("Will initialise chat handler as a spigot server!"));
                 }
             }
-            else if (PLATFORM.equals("paper") && CHAT_HANDLER.equals("auto")){
-                    CHAT_HANDLER = "paper";
+
             }
+        if (PLATFORM.equals("paper") && CHAT_HANDLER.equals("auto")){
+            CHAT_HANDLER = "paper";
+
         }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,4 +28,10 @@ use-chat-preview: true
 
 # these settings below affect gameplay, so they will stay off by default until there is a solution to make the uwufication client side only
 signs-uwuify: false
+# this settings is very dangerous
 books-uwuify: false
+
+# these settings probably don't need to be touched
+
+# "paper" || "spigot" || "auto"
+chat-handler: "auto"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,3 +5,4 @@ api-version: 1.19
 authors: [ TreeCaptcha ]
 description: made with stolen code from Ran-helo/uwu
 website: http://treecaptcha.ml/
+softdepend: [ DiscordSRV ]


### PR DESCRIPTION
This would close #5.

Spigot: Basically made the EventPriority for the AsyncPlayerChatEvent highest so it'll send UwUified messages to DiscordSRV.

Paper: This was a bit more complicated. Basically on enable we check if DiscordSRV is loaded, and if so, we'll check for which chat event they're using (it's in their config). If they're using Spigot's, Paper will revert back to Spigot's chat event and give a warning to the user every time there's a message sent (for fun yk).